### PR TITLE
style: warm neutral editorial color palette

### DIFF
--- a/src/App.res
+++ b/src/App.res
@@ -25,7 +25,7 @@ Emotion.Css.injectGlobal(`
   will-change: filter;
 }
 .logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+  filter: drop-shadow(0 0 2em #c8a45caa);
 }
 .logo.react:hover {
   filter: drop-shadow(0 0 2em #61dafbaa);
@@ -48,7 +48,7 @@ Emotion.Css.injectGlobal(`
 
 /* Hero section gradients */
 .hero-gradient {
-  background: linear-gradient(135deg, #646cff 0%, #535bf2 50%, #4338ca 100%);
+  background: linear-gradient(135deg, #c8a45c 0%, #c47d4a 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -87,7 +87,7 @@ module HeroSection = {
       "justifyContent": "center",
       "textAlign": "center",
       "padding": "2rem 1rem",
-      "background": "linear-gradient(135deg, rgba(100, 108, 255, 0.1) 0%, rgba(83, 91, 242, 0.1) 100%)"
+      "background": "linear-gradient(180deg, rgba(200, 164, 92, 0.04) 0%, transparent 100%)"
     })
 
     let logoContainerStyles = css({
@@ -108,7 +108,7 @@ module HeroSection = {
         {React.string("Modern React Development")}
       </Components.Typography.Display>
 
-      <Components.Typography.Heading level=#h2 size=#xl className={css({"color": "rgba(255, 255, 255, 0.6)", "marginTop": "1rem", "maxWidth": "600px"})}>
+      <Components.Typography.Heading level=#h2 size=#xl className={css({"color": "#9a9084", "marginTop": "1rem", "maxWidth": "600px"})}>
         {React.string("Built with Rspack, ReScript, React, and Bun for lightning-fast development")}
       </Components.Typography.Heading>
 
@@ -181,8 +181,8 @@ module ComponentsSection = {
 
     let sectionStyles = css({
       "padding": "4rem 1rem",
-      "backgroundColor": "rgba(45, 45, 45, 0.3)",
-      "borderTop": "1px solid #374151"
+      "backgroundColor": "rgba(36, 33, 32, 0.5)",
+      "borderTop": "1px solid #33302c"
     })
 
     let containerStyles = css({
@@ -203,7 +203,7 @@ module ComponentsSection = {
           {React.string("Component Library")}
         </Components.Typography.Display>
 
-        <Components.Typography.Body size=#lg align=#center className={css({"marginTop": "1rem", "color": "rgba(255, 255, 255, 0.6)"})}>
+        <Components.Typography.Body size=#lg align=#center className={css({"marginTop": "1rem", "color": "#9a9084"})}>
           {React.string("Explore our comprehensive component library with variants, sizes, and states")}
         </Components.Typography.Body>
 
@@ -308,9 +308,9 @@ module App = {
       <FeaturesSection />
       <ComponentsSection />
 
-      <footer className={css({"padding": "2rem", "textAlign": "center", "borderTop": "1px solid #374151", "marginTop": "2rem"})}>
+      <footer className={css({"padding": "2rem", "textAlign": "center", "borderTop": "1px solid #33302c", "marginTop": "2rem"})}>
         <Components.Typography.Caption>
-          {React.string("Built with ❤️ using Rspack + ReScript + React + Bun")}
+          {React.string("Built with Rspack + ReScript + React + Bun")}
         </Components.Typography.Caption>
       </footer>
     </div>

--- a/src/bindings/Emotion.res
+++ b/src/bindings/Emotion.res
@@ -247,11 +247,11 @@ module Utils = {
 
     let getFocusShadow = (color) => {
       switch color {
-      | "primary" => "0 0 0 3px rgba(100, 108, 255, 0.1)"
-      | "success" => "0 0 0 3px rgba(34, 197, 94, 0.1)"
-      | "warning" => "0 0 0 3px rgba(245, 158, 11, 0.1)"
-      | "error" => "0 0 0 3px rgba(239, 68, 68, 0.1)"
-      | _ => "0 0 0 3px rgba(100, 108, 255, 0.1)"
+      | "primary" => "0 0 0 3px rgba(200, 164, 92, 0.25)"
+      | "success" => "0 0 0 3px rgba(34, 197, 94, 0.25)"
+      | "warning" => "0 0 0 3px rgba(245, 158, 11, 0.25)"
+      | "error" => "0 0 0 3px rgba(239, 68, 68, 0.25)"
+      | _ => "0 0 0 3px rgba(200, 164, 92, 0.25)"
       }
     }
 

--- a/src/components/Button/Button.res
+++ b/src/components/Button/Button.res
@@ -74,11 +74,11 @@ module Button = {
       ])
     | #secondary => cx([
         css({
-          "backgroundColor": "#e5e7eb",
-          "color": "#374151"
+          "backgroundColor": "#33302c",
+          "color": "#ece4d8"
         }),
-        hover({"backgroundColor": "#d1d5db"}),
-        focus({"boxShadow": "0 0 0 2px rgba(156, 163, 175, 0.5)"})
+        hover({"backgroundColor": "#3d3935"}),
+        focus({"boxShadow": "0 0 0 2px rgba(200, 164, 92, 0.2)"})
       ])
     | #outline => cx([
         css({
@@ -97,7 +97,7 @@ module Button = {
           "backgroundColor": "transparent",
           "color": Color.primary
         }),
-        hover({"backgroundColor": "rgba(100, 108, 255, 0.1)"}),
+        hover({"backgroundColor": "rgba(200, 164, 92, 0.08)"}),
         focus({"boxShadow": Shadow.getFocusShadow("primary")})
       ])
     | #danger => cx([
@@ -105,7 +105,7 @@ module Button = {
           "backgroundColor": Color.error,
           "color": "white"
         }),
-        hover({"backgroundColor": "#dc2626"}),
+        hover({"backgroundColor": "#b91c1c"}),
         focus({"boxShadow": Shadow.getFocusShadow("error")})
       ])
     }

--- a/src/components/Button/Button.res
+++ b/src/components/Button/Button.res
@@ -78,7 +78,7 @@ module Button = {
           "color": "#ece4d8"
         }),
         hover({"backgroundColor": "#3d3935"}),
-        focus({"boxShadow": "0 0 0 2px rgba(200, 164, 92, 0.2)"})
+        focus({"boxShadow": Shadow.getFocusShadow("primary")})
       ])
     | #outline => cx([
         css({

--- a/src/components/Card/Card.res
+++ b/src/components/Card/Card.res
@@ -23,17 +23,17 @@ module Card = {
   let getVariantStyles = (variant: variant) => {
     switch variant {
     | #elevated => css({
-        "backgroundColor": "#2d2d2d",
-        "boxShadow": "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
-        "border": "1px solid transparent"
+        "backgroundColor": "#242120",
+        "boxShadow": "0 4px 6px -1px rgb(0 0 0 / 0.3), 0 2px 4px -2px rgb(0 0 0 / 0.2)",
+        "border": "1px solid #33302c"
       })
     | #outlined => css({
-        "backgroundColor": "#1a1a1a",
-        "border": "1px solid #374151",
+        "backgroundColor": "#1a1816",
+        "border": "1px solid #33302c",
         "boxShadow": "none"
       })
     | #filled => css({
-        "backgroundColor": "#333333",
+        "backgroundColor": "#242120",
         "border": "1px solid transparent",
         "boxShadow": "none"
       })
@@ -111,7 +111,7 @@ module Card = {
         css({
           "padding": Space.getSpacing("4"),
           "paddingBottom": Space.getSpacing("2"),
-          "borderBottom": "1px solid #374151"
+          "borderBottom": "1px solid #33302c"
         }),
         className
       ])
@@ -146,7 +146,7 @@ module Card = {
         css({
           "padding": Space.getSpacing("4"),
           "paddingTop": Space.getSpacing("2"),
-          "borderTop": "1px solid #374151",
+          "borderTop": "1px solid #33302c",
           "display": "flex",
           "alignItems": "center",
           "justifyContent": "flex-end"

--- a/src/components/Input/Input.res
+++ b/src/components/Input/Input.res
@@ -46,10 +46,10 @@ module Input = {
     switch variant {
     | #default => cx([
         css({
-          "backgroundColor": "#1a1a1a",
-          "border": `1px solid #374151`,
+          "backgroundColor": "#141210",
+          "border": `1px solid #33302c`,
           "borderRadius": Border.getRadius("md"),
-          "color": "rgba(255, 255, 255, 0.87)"
+          "color": "#ece4d8"
         }),
         focus({
           "borderColor": Color.primary,
@@ -58,14 +58,14 @@ module Input = {
       ])
     | #filled => cx([
         css({
-          "backgroundColor": "#2d2d2d",
+          "backgroundColor": "#242120",
           "border": "1px solid transparent",
           "borderRadius": Border.getRadius("md"),
-          "color": "rgba(255, 255, 255, 0.87)"
+          "color": "#ece4d8"
         }),
-        hover({"backgroundColor": "#333333"}),
+        hover({"backgroundColor": "#33302c"}),
         focus({
-          "backgroundColor": "#1a1a1a",
+          "backgroundColor": "#141210",
           "borderColor": Color.primary,
           "boxShadow": Shadow.getFocusShadow("primary")
         })
@@ -73,9 +73,9 @@ module Input = {
     | #outlined => cx([
         css({
           "backgroundColor": "transparent",
-          "border": `2px solid #374151`,
+          "border": `2px solid #33302c`,
           "borderRadius": Border.getRadius("md"),
-          "color": "rgba(255, 255, 255, 0.87)"
+          "color": "#ece4d8"
         }),
         focus({
           "borderColor": Color.primary,
@@ -86,9 +86,9 @@ module Input = {
         css({
           "backgroundColor": "transparent",
           "border": "none",
-          "borderBottom": `2px solid #374151`,
+          "borderBottom": `2px solid #33302c`,
           "borderRadius": "0",
-          "color": "rgba(255, 255, 255, 0.87)",
+          "color": "#ece4d8",
           "padding": "0.5rem 0"
         }),
         focus({
@@ -125,13 +125,13 @@ module Input = {
   })
 
   let getReadOnlyStyles = () => css({
-    "backgroundColor": "#1f1f1f",
+    "backgroundColor": "#1a1816",
     "cursor": "default"
   })
 
   let getPlaceholderStyles = () => css({
     "::placeholder": {
-      "color": "rgba(255, 255, 255, 0.6)",
+      "color": "#5c564e",
       "opacity": "1"
     }
   })

--- a/src/components/Typography/Typography.res
+++ b/src/components/Typography/Typography.res
@@ -14,7 +14,7 @@ module Typography = {
     "margin": "0",
     "fontFamily": "Inter, Avenir, Helvetica, Arial, sans-serif",
     "lineHeight": "1.5",
-    "color": "rgba(255, 255, 255, 0.87)"
+    "color": "#ece4d8"
   })
 
   // Variant styles
@@ -41,7 +41,7 @@ module Typography = {
         "fontSize": "0.875rem",
         "fontWeight": "400",
         "lineHeight": "1.25",
-        "color": "rgba(255, 255, 255, 0.6)"
+        "color": "#9a9084"
       })
     | #overline => css({
         "fontSize": "0.75rem",
@@ -49,7 +49,7 @@ module Typography = {
         "lineHeight": "1.25",
         "letterSpacing": "0.1em",
         "textTransform": "uppercase",
-        "color": "rgba(255, 255, 255, 0.6)"
+        "color": "#9a9084"
       })
     }
   }

--- a/src/styles/ComponentStyles.res
+++ b/src/styles/ComponentStyles.res
@@ -56,59 +56,59 @@ module Button = {
   let variant = (variant: variant) => {
     switch variant {
     | #primary => css({
-        "backgroundColor": "#646cff",
-        "color": "white",
+        "backgroundColor": "#c8a45c",
+        "color": "#1a1816",
         ":hover": {
-          "backgroundColor": "#4f46e5"
+          "backgroundColor": "#a88540"
         },
         ":focus": {
-          "boxShadow": "0 0 0 3px rgba(100, 108, 255, 0.1)"
+          "boxShadow": "0 0 0 3px rgba(200, 164, 92, 0.25)"
         },
         ":active": {
-          "backgroundColor": "#4f46e5",
+          "backgroundColor": "#a88540",
           "transform": "translateY(1px)"
         }
       })
     | #secondary => css({
-        "backgroundColor": "#e5e7eb",
-        "color": "#374151",
+        "backgroundColor": "#33302c",
+        "color": "#ece4d8",
         ":hover": {
-          "backgroundColor": "#d1d5db"
+          "backgroundColor": "#3d3935"
         },
         ":focus": {
-          "boxShadow": "0 0 0 2px rgba(156, 163, 175, 0.5)"
+          "boxShadow": "0 0 0 2px rgba(200, 164, 92, 0.2)"
         }
       })
     | #outline => css({
         "backgroundColor": "transparent",
-        "color": "#646cff",
-        "border": "1px solid #646cff",
+        "color": "#c8a45c",
+        "border": "1px solid #c8a45c",
         ":hover": {
-          "backgroundColor": "#646cff",
-          "color": "white"
+          "backgroundColor": "#c8a45c",
+          "color": "#1a1816"
         },
         ":focus": {
-          "boxShadow": "0 0 0 3px rgba(100, 108, 255, 0.1)"
+          "boxShadow": "0 0 0 3px rgba(200, 164, 92, 0.25)"
         }
       })
     | #ghost => css({
         "backgroundColor": "transparent",
-        "color": "#646cff",
+        "color": "#c8a45c",
         ":hover": {
-          "backgroundColor": "#f3f4f6"
+          "backgroundColor": "rgba(200, 164, 92, 0.08)"
         },
         ":focus": {
-          "boxShadow": "0 0 0 3px rgba(100, 108, 255, 0.1)"
+          "boxShadow": "0 0 0 3px rgba(200, 164, 92, 0.25)"
         }
       })
     | #danger => css({
         "backgroundColor": "#ef4444",
         "color": "white",
         ":hover": {
-          "backgroundColor": "#dc2626"
+          "backgroundColor": "#b91c1c"
         },
         ":focus": {
-          "boxShadow": "0 0 0 3px rgba(239, 68, 68, 0.1)"
+          "boxShadow": "0 0 0 3px rgba(239, 68, 68, 0.25)"
         }
       })
     }
@@ -138,20 +138,20 @@ module Input = {
 
   let base = css({
     "width": "100%",
-    "border": "1px solid #d1d5db",
+    "border": "1px solid #33302c",
     "borderRadius": "0.375rem",
     "fontSize": "1rem",
     "fontFamily": "inherit",
-    "color": "#374151",
-    "backgroundColor": "#ffffff",
+    "color": "#ece4d8",
+    "backgroundColor": "#141210",
     "transition": "all 200ms ease-out",
     "outline": "none",
     ":focus": {
-      "borderColor": "#646cff",
-      "boxShadow": "0 0 0 3px rgba(100, 108, 255, 0.1)"
+      "borderColor": "#c8a45c",
+      "boxShadow": "0 0 0 3px rgba(200, 164, 92, 0.25)"
     },
     "::placeholder": {
-      "color": "#9ca3af"
+      "color": "#5c564e"
     }
   })
 
@@ -182,14 +182,14 @@ module Input = {
         "borderColor": "#ef4444",
         ":focus": {
           "borderColor": "#ef4444",
-          "boxShadow": "0 0 0 3px rgba(239, 68, 68, 0.1)"
+          "boxShadow": "0 0 0 3px rgba(239, 68, 68, 0.25)"
         }
       })
     | #success => css({
         "borderColor": "#22c55e",
         ":focus": {
           "borderColor": "#22c55e",
-          "boxShadow": "0 0 0 3px rgba(34, 197, 94, 0.1)"
+          "boxShadow": "0 0 0 3px rgba(34, 197, 94, 0.25)"
         }
       })
     }
@@ -198,7 +198,7 @@ module Input = {
   let disabled = css({
     "opacity": "0.6",
     "cursor": "not-allowed",
-    "backgroundColor": "#f9fafb"
+    "backgroundColor": "#1a1816"
   })
 }
 
@@ -215,21 +215,21 @@ module Card = {
   let variant = (variant: variant) => {
     switch variant {
     | #elevated => css({
-        "backgroundColor": "#ffffff",
-        "boxShadow": "0 4px 6px -1px rgb(0 0 0 / 0.1)",
+        "backgroundColor": "#242120",
+        "boxShadow": "0 4px 6px -1px rgb(0 0 0 / 0.3)",
         ":hover": {
-          "boxShadow": "0 10px 15px -3px rgb(0 0 0 / 0.1)"
+          "boxShadow": "0 10px 15px -3px rgb(0 0 0 / 0.3)"
         }
       })
     | #outlined => css({
-        "backgroundColor": "#ffffff",
-        "border": "1px solid #e5e7eb",
+        "backgroundColor": "#1a1816",
+        "border": "1px solid #33302c",
         ":hover": {
-          "borderColor": "#d1d5db"
+          "borderColor": "#3d3935"
         }
       })
     | #filled => css({
-        "backgroundColor": "#f9fafb"
+        "backgroundColor": "#242120"
       })
     }
   }
@@ -278,7 +278,7 @@ module Typography = {
       "fontSize": fontSize,
       "fontWeight": fontWeight,
       "lineHeight": "1.25",
-      "color": "#374151",
+      "color": "#ece4d8",
       "marginBottom": "1rem"
     })
   }
@@ -303,10 +303,10 @@ module Typography = {
     }
 
     let textColor = switch color {
-    | Some("secondary") => "#6b7280"
-    | Some("disabled") => "#9ca3af"
+    | Some("secondary") => "#9a9084"
+    | Some("disabled") => "#5c564e"
     | Some(custom) => custom
-    | None => "#374151"
+    | None => "#ece4d8"
     }
 
     css({

--- a/src/styles/ComponentStyles.res
+++ b/src/styles/ComponentStyles.res
@@ -76,7 +76,7 @@ module Button = {
           "backgroundColor": "#3d3935"
         },
         ":focus": {
-          "boxShadow": "0 0 0 2px rgba(200, 164, 92, 0.2)"
+          "boxShadow": "0 0 0 3px rgba(200, 164, 92, 0.25)"
         }
       })
     | #outline => css({

--- a/src/styles/GlobalStyles.res
+++ b/src/styles/GlobalStyles.res
@@ -21,8 +21,8 @@ let injectGlobalStyles = () => {
       font-size: 1rem;
       font-weight: 400;
       line-height: 1.5;
-      color: rgba(255, 255, 255, 0.87);
-      background-color: #242424;
+      color: #ece4d8;
+      background-color: #1a1816;
       min-height: 100vh;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
@@ -30,7 +30,7 @@ let injectGlobalStyles = () => {
 
     /* Typography Elements */
     h1, h2, h3, h4, h5, h6 {
-      color: rgba(255, 255, 255, 0.87);
+      color: #ece4d8;
       font-weight: 600;
       line-height: 1.25;
       margin-bottom: 1rem;
@@ -45,24 +45,24 @@ let injectGlobalStyles = () => {
 
     p {
       margin-bottom: 1rem;
-      color: rgba(255, 255, 255, 0.87);
+      color: #ece4d8;
     }
 
     /* Link Styles */
     a {
-      color: #646cff;
+      color: #c8a45c;
       text-decoration: none;
       font-weight: 500;
       transition: color 200ms ease-out;
     }
 
     a:hover {
-      color: #818cf8;
+      color: #dfc088;
       text-decoration: underline;
     }
 
     a:focus {
-      outline: 2px solid #646cff;
+      outline: 2px solid #c8a45c;
       outline-offset: 2px;
       border-radius: 0.125rem;
     }
@@ -71,18 +71,18 @@ let injectGlobalStyles = () => {
     code {
       font-family: 'Fira Code', Monaco, 'Cascadia Code', monospace;
       font-size: 0.875em;
-      background-color: #2d2d2d;
+      background-color: #242120;
       padding: 0.25rem 0.5rem;
       border-radius: 0.125rem;
-      border: 1px solid #374151;
+      border: 1px solid #33302c;
     }
 
     pre {
       font-family: 'Fira Code', Monaco, 'Cascadia Code', monospace;
-      background-color: #2d2d2d;
+      background-color: #242120;
       padding: 1rem;
       border-radius: 0.375rem;
-      border: 1px solid #374151;
+      border: 1px solid #33302c;
       overflow-x: auto;
       margin-bottom: 1rem;
     }
@@ -107,22 +107,22 @@ let injectGlobalStyles = () => {
     }
 
     input, textarea, select {
-      background-color: #1a1a1a;
-      border: 1px solid #374151;
+      background-color: #141210;
+      border: 1px solid #33302c;
       border-radius: 0.375rem;
       padding: 0.5rem 0.75rem;
-      color: rgba(255, 255, 255, 0.87);
+      color: #ece4d8;
       transition: all 200ms ease-out;
     }
 
     input:focus, textarea:focus, select:focus {
       outline: none;
-      border-color: #646cff;
-      box-shadow: 0 0 0 3px rgba(100, 108, 255, 0.1);
+      border-color: #c8a45c;
+      box-shadow: 0 0 0 3px rgba(200, 164, 92, 0.25);
     }
 
     input::placeholder, textarea::placeholder {
-      color: rgba(255, 255, 255, 0.6);
+      color: #5c564e;
     }
 
     /* Utility Classes */
@@ -136,42 +136,6 @@ let injectGlobalStyles = () => {
       clip: rect(0, 0, 0, 0);
       white-space: nowrap;
       border: 0;
-    }
-
-    /* Light theme overrides */
-    @media (prefers-color-scheme: light) {
-      body {
-        color: #213547;
-        background-color: #ffffff;
-      }
-
-      h1, h2, h3, h4, h5, h6, p {
-        color: #213547;
-      }
-
-      a:hover {
-        color: #4338ca;
-      }
-
-      code {
-        background-color: #f3f4f6;
-        border-color: #e5e7eb;
-      }
-
-      pre {
-        background-color: #f9fafb;
-        border-color: #e5e7eb;
-      }
-
-      input, textarea, select {
-        background-color: #ffffff;
-        border-color: #d1d5db;
-        color: #213547;
-      }
-
-      input::placeholder, textarea::placeholder {
-        color: #6b7280;
-      }
     }
 
     /* Reduced Motion */

--- a/src/styles/GlobalStyles.res
+++ b/src/styles/GlobalStyles.res
@@ -122,7 +122,7 @@ let injectGlobalStyles = () => {
     }
 
     input::placeholder, textarea::placeholder {
-      color: #5c564e;
+      color: #7a7268;
     }
 
     /* Utility Classes */

--- a/src/styles/Styles.res
+++ b/src/styles/Styles.res
@@ -1,6 +1,6 @@
 module Styles = {
   open Emotion.Css
-  let container = css({"border": "1px solid black", "padding": "2rem", "margin": "2rem"})
+  let container = css({"border": "1px solid #33302c", "padding": "2rem", "margin": "2rem"})
   let button = css({"padding": "1rem"})
   let label = css({"padding": "1rem"})
   let input = css({"padding": "1rem"})

--- a/src/styles/Theme.res
+++ b/src/styles/Theme.res
@@ -4,12 +4,12 @@ module Theme = {
   module Colors = {
     // Brand Colors
     let brand = {
-      "primary": "#646cff",
-      "primary-light": "#818cf8",
-      "primary-dark": "#4f46e5",
-      "secondary": "#535bf2",
-      "secondary-light": "#6366f1",
-      "secondary-dark": "#4338ca",
+      "primary": "#c8a45c",
+      "primary-light": "#dfc088",
+      "primary-dark": "#a88540",
+      "secondary": "#c47d4a",
+      "secondary-light": "#d9996c",
+      "secondary-dark": "#a86638",
     }
 
     // Semantic Colors
@@ -58,18 +58,18 @@ module Theme = {
 
     // Theme-aware colors
     let text = {
-      "primary": "rgba(255, 255, 255, 0.87)",
-      "secondary": "rgba(255, 255, 255, 0.6)",
-      "disabled": "rgba(255, 255, 255, 0.38)",
-      "inverse": "#213547",
+      "primary": "#ece4d8",
+      "secondary": "#9a9084",
+      "disabled": "#5c564e",
+      "inverse": "#1a1816",
     }
 
     let background = {
-      "primary": "#242424",
-      "secondary": "#1a1a1a",
-      "elevated": "#2d2d2d",
-      "overlay": "rgba(0, 0, 0, 0.6)",
-      "inverse": "#ffffff",
+      "primary": "#1a1816",
+      "secondary": "#141210",
+      "elevated": "#242120",
+      "overlay": "rgba(0, 0, 0, 0.5)",
+      "inverse": "#f5f0e8",
     }
   }
 
@@ -189,10 +189,10 @@ module Theme = {
     }
 
     let colored = {
-      "primary": "0 0 0 3px rgba(100, 108, 255, 0.1)",
-      "success": "0 0 0 3px rgba(34, 197, 94, 0.1)",
-      "warning": "0 0 0 3px rgba(245, 158, 11, 0.1)",
-      "error": "0 0 0 3px rgba(239, 68, 68, 0.1)",
+      "primary": "0 0 0 3px rgba(200, 164, 92, 0.25)",
+      "success": "0 0 0 3px rgba(34, 197, 94, 0.25)",
+      "warning": "0 0 0 3px rgba(245, 158, 11, 0.25)",
+      "error": "0 0 0 3px rgba(239, 68, 68, 0.25)",
     }
   }
 


### PR DESCRIPTION
## Summary
- Replace blue/purple tech palette with warm neutrals — gold accent (#c8a45c), warm charcoal surfaces (#1a1816), cream text (#ece4d8)
- Remove `prefers-color-scheme: light` media query that conflicted with dark-only components
- Update all 10 style/component files for palette consistency

## Test plan
- [x] `bun run res:build` compiles without errors
- [x] Dev server renders correctly at localhost:8080
- [ ] Verify text readability across all sections
- [ ] Check button, card, input, and typography variants render with correct colors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Comprehensive color scheme redesign: shifted from purple/blue to a warmer gold/brown palette across UI
  * Updated text, background, border, focus and shadow colors for buttons, inputs, cards, typography, and global styles for improved hierarchy
  * Removed light-theme overrides to streamline a single dark theme

* **Chores**
  * Minor UI text tweak: footer caption emoji removed for a cleaner message
<!-- end of auto-generated comment: release notes by coderabbit.ai -->