### PR TITLE
refactor(styles): centralize hardcoded colors into theme tokens

### DIFF
--- a/src/App.res
+++ b/src/App.res
@@ -107,7 +107,7 @@ module HeroSection = {
         {React.string("Modern React Development")}
       </Components.Typography.Display>
 
-      <Components.Typography.Heading level=#h2 size=#xl className={css({"color": "#9a9084", "marginTop": "1rem", "maxWidth": "600px"})}>
+      <Components.Typography.Heading level=#h2 size=#xl className={css({"color": Theme.Theme.Colors.text["secondary"], "marginTop": "1rem", "maxWidth": "600px"})}>
         {React.string("Built with Rspack, ReScript, React, and Bun for lightning-fast development")}
       </Components.Typography.Heading>
 
@@ -180,8 +180,8 @@ module ComponentsSection = {
 
     let sectionStyles = css({
       "padding": "4rem 1rem",
-      "backgroundColor": "rgba(36, 33, 32, 0.5)",
-      "borderTop": "1px solid #33302c"
+      "backgroundColor": `${Theme.Theme.Colors.background["elevated"]}80`,
+      "borderTop": `1px solid ${Theme.Theme.Colors.border["default"]}`
     })
 
     let containerStyles = css({
@@ -202,7 +202,7 @@ module ComponentsSection = {
           {React.string("Component Library")}
         </Components.Typography.Display>
 
-        <Components.Typography.Body size=#lg align=#center className={css({"marginTop": "1rem", "color": "#9a9084"})}>
+        <Components.Typography.Body size=#lg align=#center className={css({"marginTop": "1rem", "color": Theme.Theme.Colors.text["secondary"]})}>
           {React.string("Explore our comprehensive component library with variants, sizes, and states")}
         </Components.Typography.Body>
 
@@ -307,7 +307,7 @@ module App = {
       <FeaturesSection />
       <ComponentsSection />
 
-      <footer className={css({"padding": "2rem", "textAlign": "center", "borderTop": "1px solid #33302c", "marginTop": "2rem"})}>
+      <footer className={css({"padding": "2rem", "textAlign": "center", "borderTop": `1px solid ${Theme.Theme.Colors.border["default"]}`, "marginTop": "2rem"})}>
         <Components.Typography.Caption>
           {React.string("Built with Rspack + ReScript + React + Bun")}
         </Components.Typography.Caption>

--- a/src/bindings/Emotion.res
+++ b/src/bindings/Emotion.res
@@ -50,19 +50,30 @@ module Utils = {
     let primaryLight = Theme.Colors.brand["primary-light"]
     let primaryDark = Theme.Colors.brand["primary-dark"]
     let secondary = Theme.Colors.brand["secondary"]
+    let secondaryLight = Theme.Colors.brand["secondary-light"]
+    let secondaryDark = Theme.Colors.brand["secondary-dark"]
 
     let success = Theme.Colors.semantic["success"]
+    let successDark = Theme.Colors.semantic["success-dark"]
     let warning = Theme.Colors.semantic["warning"]
     let error = Theme.Colors.semantic["error"]
+    let errorDark = Theme.Colors.semantic["error-dark"]
     let info = Theme.Colors.semantic["info"]
 
     let textPrimary = Theme.Colors.text["primary"]
     let textSecondary = Theme.Colors.text["secondary"]
     let textDisabled = Theme.Colors.text["disabled"]
+    let textInverse = Theme.Colors.text["inverse"]
 
     let bgPrimary = Theme.Colors.background["primary"]
     let bgSecondary = Theme.Colors.background["secondary"]
     let bgElevated = Theme.Colors.background["elevated"]
+    let bgOverlay = Theme.Colors.background["overlay"]
+
+    let border = Theme.Colors.border["default"]
+    let borderHover = Theme.Colors.border["hover"]
+
+    let placeholder = Theme.Colors.placeholder
   }
 
   // Typography utilities
@@ -226,7 +237,7 @@ module Utils = {
     }
 
     let rounded = (~size="base", ()) => css({"borderRadius": getRadius(size)})
-    let border = (~width="1", ~color="#e5e7eb", ()) =>
+    let border = (~width="1", ~color=Theme.Colors.border["default"], ()) =>
       css({"border": `${getBorderWidth(width)} solid ${color}`})
   }
 

--- a/src/components/Button/Button.res
+++ b/src/components/Button/Button.res
@@ -63,7 +63,7 @@ module Button = {
     | #primary => cx([
         css({
           "backgroundColor": Color.primary,
-          "color": "white"
+          "color": Color.textInverse
         }),
         hover({"backgroundColor": Color.primaryDark}),
         focus({"boxShadow": Shadow.getFocusShadow("primary")}),
@@ -74,10 +74,10 @@ module Button = {
       ])
     | #secondary => cx([
         css({
-          "backgroundColor": "#33302c",
-          "color": "#ece4d8"
+          "backgroundColor": Color.border,
+          "color": Color.textPrimary
         }),
-        hover({"backgroundColor": "#3d3935"}),
+        hover({"backgroundColor": Color.borderHover}),
         focus({"boxShadow": Shadow.getFocusShadow("primary")})
       ])
     | #outline => cx([
@@ -88,7 +88,7 @@ module Button = {
         }),
         hover({
           "backgroundColor": Color.primary,
-          "color": "white"
+          "color": Color.textInverse
         }),
         focus({"boxShadow": Shadow.getFocusShadow("primary")})
       ])
@@ -97,7 +97,7 @@ module Button = {
           "backgroundColor": "transparent",
           "color": Color.primary
         }),
-        hover({"backgroundColor": "rgba(200, 164, 92, 0.08)"}),
+        hover({"backgroundColor": `${Color.primary}14`}),
         focus({"boxShadow": Shadow.getFocusShadow("primary")})
       ])
     | #danger => cx([
@@ -105,7 +105,7 @@ module Button = {
           "backgroundColor": Color.error,
           "color": "white"
         }),
-        hover({"backgroundColor": "#b91c1c"}),
+        hover({"backgroundColor": Color.errorDark}),
         focus({"boxShadow": Shadow.getFocusShadow("error")})
       ])
     }

--- a/src/components/Card/Card.res
+++ b/src/components/Card/Card.res
@@ -23,17 +23,17 @@ module Card = {
   let getVariantStyles = (variant: variant) => {
     switch variant {
     | #elevated => css({
-        "backgroundColor": "#242120",
-        "boxShadow": "0 4px 6px -1px rgb(0 0 0 / 0.3), 0 2px 4px -2px rgb(0 0 0 / 0.2)",
-        "border": "1px solid #33302c"
+        "backgroundColor": Color.bgElevated,
+        "boxShadow": Shadow.getShadow("md"),
+        "border": `1px solid ${Color.border}`
       })
     | #outlined => css({
-        "backgroundColor": "#1a1816",
-        "border": "1px solid #33302c",
+        "backgroundColor": Color.bgPrimary,
+        "border": `1px solid ${Color.border}`,
         "boxShadow": "none"
       })
     | #filled => css({
-        "backgroundColor": "#242120",
+        "backgroundColor": Color.bgElevated,
         "border": "1px solid transparent",
         "boxShadow": "none"
       })
@@ -111,7 +111,7 @@ module Card = {
         css({
           "padding": Space.getSpacing("4"),
           "paddingBottom": Space.getSpacing("2"),
-          "borderBottom": "1px solid #33302c"
+          "borderBottom": `1px solid ${Color.border}`
         }),
         className
       ])
@@ -146,7 +146,7 @@ module Card = {
         css({
           "padding": Space.getSpacing("4"),
           "paddingTop": Space.getSpacing("2"),
-          "borderTop": "1px solid #33302c",
+          "borderTop": `1px solid ${Color.border}`,
           "display": "flex",
           "alignItems": "center",
           "justifyContent": "flex-end"

--- a/src/components/Input/Input.res
+++ b/src/components/Input/Input.res
@@ -46,10 +46,10 @@ module Input = {
     switch variant {
     | #default => cx([
         css({
-          "backgroundColor": "#141210",
-          "border": `1px solid #33302c`,
+          "backgroundColor": Color.bgSecondary,
+          "border": `1px solid ${Color.border}`,
           "borderRadius": Border.getRadius("md"),
-          "color": "#ece4d8"
+          "color": Color.textPrimary
         }),
         focus({
           "borderColor": Color.primary,
@@ -58,14 +58,14 @@ module Input = {
       ])
     | #filled => cx([
         css({
-          "backgroundColor": "#242120",
+          "backgroundColor": Color.bgElevated,
           "border": "1px solid transparent",
           "borderRadius": Border.getRadius("md"),
-          "color": "#ece4d8"
+          "color": Color.textPrimary
         }),
-        hover({"backgroundColor": "#33302c"}),
+        hover({"backgroundColor": Color.border}),
         focus({
-          "backgroundColor": "#141210",
+          "backgroundColor": Color.bgSecondary,
           "borderColor": Color.primary,
           "boxShadow": Shadow.getFocusShadow("primary")
         })
@@ -73,9 +73,9 @@ module Input = {
     | #outlined => cx([
         css({
           "backgroundColor": "transparent",
-          "border": `2px solid #33302c`,
+          "border": `2px solid ${Color.border}`,
           "borderRadius": Border.getRadius("md"),
-          "color": "#ece4d8"
+          "color": Color.textPrimary
         }),
         focus({
           "borderColor": Color.primary,
@@ -86,9 +86,9 @@ module Input = {
         css({
           "backgroundColor": "transparent",
           "border": "none",
-          "borderBottom": `2px solid #33302c`,
+          "borderBottom": `2px solid ${Color.border}`,
           "borderRadius": "0",
-          "color": "#ece4d8",
+          "color": Color.textPrimary,
           "padding": "0.5rem 0"
         }),
         focus({
@@ -125,13 +125,13 @@ module Input = {
   })
 
   let getReadOnlyStyles = () => css({
-    "backgroundColor": "#1a1816",
+    "backgroundColor": Color.bgPrimary,
     "cursor": "default"
   })
 
   let getPlaceholderStyles = () => css({
     "::placeholder": {
-      "color": "#5c564e",
+      "color": Color.placeholder,
       "opacity": "1"
     }
   })

--- a/src/components/Typography/Typography.res
+++ b/src/components/Typography/Typography.res
@@ -13,7 +13,7 @@ module Typography = {
     "margin": "0",
     "fontFamily": "Inter, Avenir, Helvetica, Arial, sans-serif",
     "lineHeight": "1.5",
-    "color": "#ece4d8"
+    "color": Theme.Theme.Colors.text["primary"]
   })
 
   // Variant styles
@@ -40,7 +40,7 @@ module Typography = {
         "fontSize": "0.875rem",
         "fontWeight": "400",
         "lineHeight": "1.25",
-        "color": "#9a9084"
+        "color": Theme.Theme.Colors.text["secondary"]
       })
     | #overline => css({
         "fontSize": "0.75rem",
@@ -48,7 +48,7 @@ module Typography = {
         "lineHeight": "1.25",
         "letterSpacing": "0.1em",
         "textTransform": "uppercase",
-        "color": "#9a9084"
+        "color": Theme.Theme.Colors.text["secondary"]
       })
     }
   }

--- a/src/styles/Styles.res
+++ b/src/styles/Styles.res
@@ -1,6 +1,6 @@
 module Styles = {
   open Emotion.Css
-  let container = css({"border": "1px solid #33302c", "padding": "2rem", "margin": "2rem"})
+  let container = css({"border": `1px solid ${Theme.Theme.Colors.border["default"]}`, "padding": "2rem", "margin": "2rem"})
   let button = css({"padding": "1rem"})
   let label = css({"padding": "1rem"})
   let input = css({"padding": "1rem"})

--- a/src/styles/Theme.res
+++ b/src/styles/Theme.res
@@ -71,6 +71,14 @@ module Theme = {
       "overlay": "rgba(0, 0, 0, 0.5)",
       "inverse": "#f5f0e8",
     }
+
+    // UI element colors
+    let border = {
+      "default": "#33302c",
+      "hover": "#3d3935",
+    }
+
+    let placeholder = "#7a7268"
   }
 
   // Typography System


### PR DESCRIPTION
## Summary
- Add `border` and `placeholder` tokens to Theme.res
- Expand Emotion.Utils Color module with `border`, `borderHover`, `placeholder`, `textInverse`, `errorDark`, `secondaryLight/Dark`
- Replace hardcoded hex values with token references across 8 files:
  - **Button.res** — secondary bg/text, ghost hover, danger hover now use tokens
  - **Card.res** — all variant backgrounds, borders, and shadows use tokens
  - **Input.res** — all variant backgrounds, borders, text, placeholder use tokens
  - **Typography.res** — base and caption/overline colors use tokens
  - **App.res** — inline section colors and borders use tokens
  - **Styles.res** — container border uses token
- Fix stale `#e5e7eb` default in Emotion Border utility

## Test plan
- [x] `bun run res:build` — 82 modules compiled, zero warnings
- [x] `bun run build` — production build succeeds
- [x] `bun run test` — all 18 tests pass

Changing any color in Theme.res now propagates across all components automatically.

Closes #50